### PR TITLE
Allow logging to stdout. Add option "-cdst".

### DIFF
--- a/ConsoleRedir.cpp
+++ b/ConsoleRedir.cpp
@@ -124,13 +124,14 @@ UINT WINAPI ListenRemoteOutPipeThread(void* p)
 		if (!ReadFile( pLP->pSettings->hStdOut, szBuffer, SIZEOF_BUFFER - 1, &dwRead, &olR) || (dwRead == 0)) 
 		{
 			DWORD dwErr = GetLastError();
-			if ( dwErr == ERROR_NO_DATA)
+			if ( dwErr != ERROR_MORE_DATA)
 				break;
 		}
 
 		if(gbStop)
 			break;
 
+		/*
 		HANDLE waits[2];
 		waits[0] = pLP->hStop;
 		waits[1] = hEvent;
@@ -138,6 +139,7 @@ UINT WINAPI ListenRemoteOutPipeThread(void* p)
 		if(ret == WAIT_OBJECT_0)
 			break; //need to exit
 		_ASSERT(ret == WAIT_OBJECT_0 + 1); //data in buffer now
+		*/
 
 		// Handle CLS command, just for fun :)
 		switch( szBuffer[0] )
@@ -219,13 +221,14 @@ UINT WINAPI ListenRemoteErrorPipeThread(void* p)
 		if(!ReadFile( pLP->pSettings->hStdErr, szBuffer, SIZEOF_BUFFER, &dwRead, &olR) || (dwRead == 0)) 
 		{
 			DWORD dwErr = GetLastError();
-			if ( dwErr == ERROR_NO_DATA)
+			if ( dwErr != ERROR_MORE_DATA)
 				break;
 		}
 
 		if(gbStop)
 			break;
 
+		/*
 		HANDLE waits[2];
 		waits[0] = pLP->hStop;
 		waits[1] = olR.hEvent;
@@ -233,7 +236,7 @@ UINT WINAPI ListenRemoteErrorPipeThread(void* p)
 		if(ret == WAIT_OBJECT_0)
 			break; //need to exit
 		_ASSERT(ret == WAIT_OBJECT_0 + 1); //data in buffer now
-
+		*/
 		szBuffer[ dwRead / sizeof(szBuffer[0]) ] = _T('\0');
 
 		// Write it to our stderr

--- a/PAExec.vcxproj
+++ b/PAExec.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -18,14 +18,14 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v120_xp</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110_xp</PlatformToolset>
+    <PlatformToolset>v120_xp</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Parsing.cpp
+++ b/Parsing.cpp
@@ -206,6 +206,7 @@ CommandList gSupportedCommands[] =
 	{L"background", false, false},
 	{L"a", true, true},
 	{L"csrc", true, true},
+	{L"cdst", true, true},
 	{L"clist", true, true},
 	{L"dfr", false, false},
 	{L"lo", true, true},
@@ -563,6 +564,13 @@ bool ParseCommandLine(Settings& settings, LPCWSTR cmdLine)
 			}
 			tmp.UnlockBuffer();
 			settings.srcDir = (LPCWSTR)tmp; //store folder
+
+			if(cmdParser.HasKey(L"cdst"))
+			{
+				FileInfo fi;
+				fi.filenameOnly = cmdParser.GetVal(L"cdst");
+				settings.destFileInfos.push_back(fi);
+			}
 		}
 
 		if(cmdParser.HasKey(L"clist"))
@@ -700,7 +708,11 @@ bool ParseCommandLine(Settings& settings, LPCWSTR cmdLine)
 			//now create destFileList based on app and srcFileList
 			FileInfo fi;
 			fi.filenameOnly = settings.app;
-			settings.destFileInfos.push_back(fi); //index 0
+			
+			if(settings.destFileInfos.empty())
+			{
+				settings.destFileInfos.push_back(fi); //index 0
+			}
 
 			if(settings.srcFileInfos.empty())
 			{

--- a/Remote.cpp
+++ b/Remote.cpp
@@ -828,7 +828,8 @@ void HandleMsg(RemMsg& msg, RemMsg& response, HANDLE hPipe)
 
 			//below line also gets version information if possible
 			pRemoteSettings->ResolveFilePaths(); //after logging is setup.  non-existent files will be marked as needing to be copied
-			pRemoteSettings->app = pRemoteSettings->destFileInfos[0].fullFilePath;
+			if (pRemoteSettings->app.Compare(pRemoteSettings->destFileInfos[0].filenameOnly) == 0) // if app not the same as dest file, don't set it
+				pRemoteSettings->app = pRemoteSettings->destFileInfos[0].fullFilePath;
 
 			int index = 0;
 			FILETIME zero = {0};


### PR DESCRIPTION
For option "-cdst", it is used to seperate app and copied files. 
"-c -csrc c:\a.py -cdst a.py cmd /C a.py" will copy a.py to remote pc and execute "cmd" /C a.py.
