### PR TITLE
Added ability to specify custom service name for PAExec remote service

### DIFF
--- a/Parsing.cpp
+++ b/Parsing.cpp
@@ -212,7 +212,8 @@ CommandList gSupportedCommands[] =
 	{L"rlo", true, true},
 	{L"dbg", false, false},
 	{L"to", true, true},
-	{L"noname", false, false}, 
+	{L"noname", false, false},
+	{L"sname", true, true},
 	{L"accepteula", false, false} //non-documented PSExec command that we'll just silently eat
 };
 
@@ -536,7 +537,9 @@ bool ParseCommandLine(Settings& settings, LPCWSTR cmdLine)
 
 		if(cmdParser.HasKey(L"noname"))
 			settings.bNoName = true;
-		
+		else if (cmdParser.HasKey(L"sname"))
+			settings.serviceName = cmdParser.GetVal(L"sname");
+
 		if(cmdParser.HasKey(L"csrc"))
 		{
 			if(false == settings.bCopyFiles)

--- a/Remote.cpp
+++ b/Remote.cpp
@@ -171,6 +171,8 @@ CString GetRemoteServiceName(Settings& settings)
 {
 	if(settings.bNoName)
 		return L"PAExec";
+	else if (!settings.serviceName.IsEmpty())
+		return settings.serviceName;
 	else
 	{
 		//Installed service will use a unique name so we can have multiple running at once

--- a/Usage.txt
+++ b/Usage.txt
@@ -8,7 +8,7 @@ Usage: PAExec [\\computer[,computer2[,...]] | @file]
 [-u user [-p psswd]|[-p@ file [-p@d]]] 
 [-n s] [-l][-s|-e][-x][-i [session]][-c [-f|-v] [-csrc path]]
 [-lo path][-rlo path][-ods][-w directory][-d][-<priority>][-a n,n,...]
-[-dfr][-noname][-to seconds] cmd [arguments]
+[-dfr][-noname][-sname name][-to seconds] cmd [arguments]
 
 Standard PAExec\PsExec command line options:
 
@@ -136,7 +136,9 @@ Additional options only available in PAExec:
      -noname   In order to robustly handle multiple simultaneous connections to a server,
                the source server's name is added to the remote service name and remote PAExec
                executable file.  If you do NOT want this behavior, use -noname
-               
+
+     -sname    Remote service name.
+               This option is not compatible with -noname
 
 The application name, copy source, working directory and log file
 entries can be quoted if the path contains a space.  For example:

--- a/stdafx.h
+++ b/stdafx.h
@@ -337,6 +337,7 @@ public:
 	bool bNeedToDeleteServiceFile;
 	bool bNeedToDeleteService;
 	bool bNoName;
+	CString serviceName;
 };
 
 class ListenParam


### PR DESCRIPTION
I'm using PAExec to execute commands under the system account. From time to time it's crashing (still investigating the reason) leaving the temporary service in the system. I've decided to do a cleanup in such situation by deleting the service if any after PAExec is terminated. But some another program may be using PAExec too and I didn't want to harm it. So I've added an option to specify service name explicitly to be able to safely delete it.
