### PR TITLE
Fix for parsing of -i 0

### DIFF
--- a/Parsing.cpp
+++ b/Parsing.cpp
@@ -287,8 +287,12 @@ bool SplitCommand(CString& restOfLine, LPCWSTR& paExecParams, LPCWSTR& appToRun)
 					//special handling for -i which may or may not have an argument, but if it does, it is numeric
 					if(0 == wcscmp(gSupportedCommands[i].cmd, L"i"))
 					{
-						if(0 == wtodw(ptr))
-							continue; //no argument
+						//wtodw(' ') and wtodw('0') both return 0
+						if(L'0' != *ptr)
+						{
+							if(0 == wtodw(ptr))
+								continue; //no argument
+						}
 					}
 					
 					bool bInQuote = false;


### PR DESCRIPTION
This is a kludge for https://github.com/poweradminllc/PAExec/issues/5... the wtodw() command sees ' ' and '0' both as 0, so the correct solution is probably to fix that, but I don't know if that will affect anything else in the program, so I just check for a literal 0 as an argument.
