### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/PAExec.cpp
+++ b/PAExec.cpp
@@ -331,7 +331,7 @@ void PrintUsage()
 	memcpy(pCopy, pB, size);
 	pCopy[size] = '\0';
 	printf("\r\n");
-	printf(pCopy);
+	printf("%s",pCopy);
 	printf("\r\n");
 	delete [] pCopy;
 }

--- a/Parsing.cpp
+++ b/Parsing.cpp
@@ -332,7 +332,7 @@ bool ParseCommandLine(Settings& settings, LPCWSTR cmdLine)
 	{
 		cmdLinePastCompList = EatWhiteSpace(cmdLinePastCompList);
 
-		if(L'\0' == cmdLinePastCompList)
+		if(L'\0' == *cmdLinePastCompList)
 			return false; //empty command line -- just show usage
 
 		if((0 == wcsncmp(cmdLinePastCompList, L"/?", 2)) || (0 == wcsncmp(cmdLinePastCompList, L"-?", 2)))


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V528](https://www.viva64.com/en/w/v528/) It is odd that pointer to 'wchar_t' type is compared with the L'\0' value. Probably meant: *cmdLinePastCompList == L'\0'. parsing.cpp 335
[V618](https://www.viva64.com/en/w/v618/) It's dangerous to call the 'printf' function in such a manner, as the line being passed could contain format specification. The example of the safe code: printf("%s", str); paexec.cpp 334