### PR TITLE
Allow to specify share path to write service file

### DIFF
--- a/PAExec.cpp
+++ b/PAExec.cpp
@@ -81,6 +81,13 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[])
 				Log(L"-lo missing value", true);
 		}
 
+		if (cmdParser.HasKey(L"share"))
+		{
+			settings.targetShare = cmdParser.GetVal(L"share");
+			if (settings.targetShare.IsEmpty())
+				Log(L"-share missing value", true);
+		}
+
 #ifdef _DEBUG
 		gbODS = true;
 #endif
@@ -223,7 +230,8 @@ PerServerCleanup:
 					if(settings.bNeedToDeleteServiceFile)
 						DeletePAExecFromRemote(*cItr, settings);
 					if(settings.bNeedToDetachFromAdmin)
-						EstablishConnection(settings, *cItr, L"ADMIN$", false);
+						//EstablishConnection(settings, *cItr, L"ADMIN$", false);
+						EstablishConnection(settings, *cItr, settings.targetShare, false);
 					if(settings.bNeedToDetachFromIPC)
 						EstablishConnection(settings, *cItr, L"IPC$", false);
 					if(false == gbStop) //if stopping, just bail -- the OS will close these (and some of them might be invalid now anyway)

--- a/Parsing.cpp
+++ b/Parsing.cpp
@@ -217,6 +217,8 @@ CommandList gSupportedCommands[] =
 	{L"to", true, true},
 	{L"noname", false, false},
 	{L"sname", true, true},
+	{L"share", true, true},
+	{L"sharepath", true, true},
 	{L"accepteula", false, false} //non-documented PSExec command that we'll just silently eat
 };
 
@@ -546,6 +548,14 @@ bool ParseCommandLine(Settings& settings, LPCWSTR cmdLine)
 			settings.bNoName = true;
 		else if (cmdParser.HasKey(L"sname"))
 			settings.serviceName = cmdParser.GetVal(L"sname");
+
+		if (cmdParser.HasKey(L"share")) {
+			settings.targetShare = cmdParser.GetVal(L"share");
+			if (cmdParser.HasKey(L"sharepath")) {
+				settings.targetSharePath = cmdParser.GetVal(L"sharepath");
+			}
+		}
+			
 
 		if(cmdParser.HasKey(L"csrc"))
 		{

--- a/Usage.txt
+++ b/Usage.txt
@@ -8,7 +8,8 @@ Usage: PAExec [\\computer[,computer2[,...]] | @file]
 [-u user [-p psswd]|[-p@ file [-p@d]]] 
 [-n s] [-l][-s|-e][-x][-i [session]][-c [-f|-v] [-csrc path]]
 [-lo path][-rlo path][-ods][-w directory][-d][-<priority>][-a n,n,...]
-[-dfr][-noname][-sname name][-to seconds] cmd [arguments]
+[-dfr][-noname][-sname name][-share share_name -sharepath share_path]
+[-to seconds] cmd [arguments]
 
 Standard PAExec\PsExec command line options:
 
@@ -139,6 +140,12 @@ Additional options only available in PAExec:
 
      -sname    Remote service name.
                This option is not compatible with -noname
+
+     -share    Remote share name.
+               -sharepath must be supplied when using this functionality
+
+     -sharepath Real path of specified remote share.
+               -sharepath can only be used with -share
 
 The application name, copy source, working directory and log file
 entries can be quoted if the path contains a space.  For example:

--- a/stdafx.h
+++ b/stdafx.h
@@ -165,6 +165,8 @@ public:
 		timeoutSeconds = 0;
 		bNoName = false;
 		sessionToInteractWith = (DWORD)-1; //not initialized
+		targetShare = L"ADMIN$";
+		targetSharePath = L"%SYSTEMROOT%";
 	}
 
 	void Serialize(RemMsg& msg, bool bSave)
@@ -338,6 +340,8 @@ public:
 	bool bNeedToDeleteService;
 	bool bNoName;
 	CString serviceName;
+	CString targetShare;
+	CString targetSharePath;
 };
 
 class ListenParam


### PR DESCRIPTION
Example usage:
```
paexec \\testserver -share d$ -sharepath D:\ cmd
paexec \\testserver -share d$\test -sharepath D:\test cmd
```

This can be extremely useful when ADMIN$ is full / forbidden to write, which you can specify an alternative share to drop files.