### PR TITLE
Fix remote code execution if not locally logged in as admin

### DIFF
--- a/Remote.cpp
+++ b/Remote.cpp
@@ -117,6 +117,13 @@ void DeletePAExecFromRemote(LPCWSTR targetComputer, Settings& settings)
 		Log(StrFormat(L"Failed to cleanup [%s] on %s.", dest, targetComputer), gle);
 		break;
 	}
+	
+	if (!BAD_HANDLE(settings.hUserImpersonated))
+	{
+		::RevertToSelf();
+		::CloseHandle(settings.hUserImpersonated);
+		settings.hUserImpersonated = INVALID_HANDLE_VALUE;
+	}
 }
 
 bool CopyPAExecToRemote(Settings& settings, LPCWSTR targetComputer)
@@ -267,12 +274,34 @@ bool InstallAndStartRemoteService(LPCWSTR remoteServer, Settings& settings)
 		gle = GetLastError();
 	}
 
+	if (BAD_HANDLE(hSCM))
+	{
+		Log(StrFormat(L"Failed to connect to Service Control Manager on %s.", remoteServer ? remoteServer : L"{local computer}"), gle);
+	}
+	
 	if(gbStop)
 		return false;
 
 	if (BAD_HANDLE(hSCM))
 	{
-		Log(StrFormat(L"Failed to connect to Service Control Manager on %s.", remoteServer ? remoteServer : L"{local computer}"), gle);
+		// If the above fails, we try a different approach that includes impersonation.
+		// This seems to happen if we do not have admin rights locally when starting a remote process.
+		// See https://docs.microsoft.com/de-de/windows/win32/api/winsvc/nf-winsvc-openscmanagera?redirectedfrom=MSDN
+		bool success = ::LogonUserW(settings.user, NULL, settings.password, LOGON32_LOGON_NEW_CREDENTIALS, LOGON32_PROVIDER_WINNT50, &settings.hUserImpersonated);
+		if (!success || BAD_HANDLE(settings.hUserImpersonated))
+		{
+			gle = GetLastError();
+			Log(StrFormat(L"Failed to log on as remote user %s.", settings.user.GetString()), gle);
+			return false;
+		}
+		::ImpersonateLoggedOnUser(settings.hUserImpersonated);
+		hSCM = ::OpenSCManager(remoteServer, NULL, SC_MANAGER_ALL_ACCESS);
+		gle = GetLastError();
+	}
+
+	if (BAD_HANDLE(hSCM))
+	{
+		Log(StrFormat(L"Failed to impersonate to open Service Control Manager on %s.", remoteServer ? remoteServer : L"{local computer}"), gle);
 		return false;
 	}
 
@@ -331,7 +360,7 @@ bool InstallAndStartRemoteService(LPCWSTR remoteServer, Settings& settings)
 		}
 		settings.bNeedToDeleteService = true;
 	}
-	
+
 	::CloseServiceHandle(hService);
 	::CloseServiceHandle(hSCM);
 

--- a/stdafx.h
+++ b/stdafx.h
@@ -150,6 +150,7 @@ public:
 		hProcess = INVALID_HANDLE_VALUE;
 		hUserProfile = INVALID_HANDLE_VALUE; //call UnloadUserProfile when done
 		hUser = INVALID_HANDLE_VALUE;
+		hUserImpersonated = INVALID_HANDLE_VALUE;
 		bDisableFileRedirection = false;
 		bODS = false;
 		hStdOut = INVALID_HANDLE_VALUE;
@@ -330,6 +331,7 @@ public:
 	DWORD processID;
 	HANDLE hUserProfile; //call UnloadUserProfile when done
 	HANDLE hUser;
+	HANDLE hUserImpersonated;
 	CString localLogPath;
 	HANDLE hStdOut;
 	HANDLE hStdIn;


### PR DESCRIPTION
This resolves an issue where paexec would fail to start its service task remotely if it is not run as admin on the _local_ computer. The solution bases on the MSDN documentation for the OpenSCManager function. You still have to provide admin credentials for the remote machine, though. 